### PR TITLE
 * webidl_binder.py: Fix argument ot being pointer for jsimplementation

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -337,7 +337,7 @@ def deref_if_nonpointer(m):
 def type_to_cdec(raw):
   name = ret = type_to_c(raw.type.name, non_pointing=True)
   if raw.getExtendedAttribute('Const'): ret = 'const ' + ret
-  if name not in interfaces: return ret
+  if raw.type.name not in interfaces: return ret
   if raw.getExtendedAttribute('Ref'):
     return ret + '&'
   if raw.getExtendedAttribute('Value'):


### PR DESCRIPTION
For issue 7425. Looks up by type name rather than the fully qualified type name